### PR TITLE
Improved support for Linux

### DIFF
--- a/PMUnifiedAPI/Controllers/QuotesController.cs
+++ b/PMUnifiedAPI/Controllers/QuotesController.cs
@@ -104,6 +104,7 @@ namespace PMUnifiedAPI.Controllers
             {
                 var indices = await _marketDataClient.GetIndices();
                 var output = JsonConvert.SerializeObject(indices);
+                Response.ContentType = "application/json";
                 return Ok(output);
             }
             catch (Exception e)

--- a/PMUnifiedAPI/Startup.cs
+++ b/PMUnifiedAPI/Startup.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
@@ -87,6 +89,15 @@ namespace PMUnifiedAPI
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            // Add header forwarding when running behind a reverse proxy on Linux hosts
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                app.UseForwardedHeaders(new ForwardedHeadersOptions
+                {
+                    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+                });
+            }
+            
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();


### PR DESCRIPTION
Improved support for Linux hosts by forwarding headers when running behind a reverse proxy, fixed content type in Indices endpoint in Quotes controller